### PR TITLE
增加移除通知监听者接口

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.0'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/library/src/main/java/com/inuker/bluetooth/library/BluetoothClient.java
+++ b/library/src/main/java/com/inuker/bluetooth/library/BluetoothClient.java
@@ -100,6 +100,14 @@ public class BluetoothClient implements IBluetoothClient {
     }
 
     @Override
+    public void unnotify(String mac, UUID service, UUID character, BleNotifyResponse response) {
+        BluetoothLog.v(String.format("unnotify %s: service = %s, character = %s", mac, service, character));
+
+        response = ProxyUtils.getUIProxy(response);
+        mClient.unnotify(mac, service, character, response);
+    }
+
+    @Override
     public void unnotify(String mac, UUID service, UUID character, BleUnnotifyResponse response) {
         BluetoothLog.v(String.format("unnotify %s: service = %s, character = %s", mac, service, character));
 

--- a/library/src/main/java/com/inuker/bluetooth/library/BluetoothClientImpl.java
+++ b/library/src/main/java/com/inuker/bluetooth/library/BluetoothClientImpl.java
@@ -373,6 +373,22 @@ public class BluetoothClientImpl implements IBluetoothClient, ProxyInterceptor, 
     }
 
     @Override
+    public void unnotify(String mac, UUID service, UUID character, BleNotifyResponse response) {
+        checkRuntime(true);
+        if (response == null) {
+            return;
+        }
+        HashMap<String, List<BleNotifyResponse>> listenerMap = mNotifyResponses.get(mac);
+        if (listenerMap != null) {
+            String key = generateCharacterKey(service, character);
+            List<BleNotifyResponse> reponseList = listenerMap.get(key);
+            if (reponseList != null) {
+                reponseList.remove(response);
+            }
+        }
+    }
+
+    @Override
     public void unnotify(final String mac, final UUID service, final UUID character, final BleUnnotifyResponse response) {
         Bundle args = new Bundle();
         args.putString(EXTRA_MAC, mac);
@@ -414,7 +430,7 @@ public class BluetoothClientImpl implements IBluetoothClient, ProxyInterceptor, 
 
     @Override
     public void unindicate(String mac, UUID service, UUID character, BleUnnotifyResponse response) {
-       unnotify(mac, service, character, response);
+        unnotify(mac, service, character, response);
     }
 
     @Override

--- a/library/src/main/java/com/inuker/bluetooth/library/IBluetoothClient.java
+++ b/library/src/main/java/com/inuker/bluetooth/library/IBluetoothClient.java
@@ -40,6 +40,8 @@ public interface IBluetoothClient {
 
     void notify(String mac, UUID service, UUID character, BleNotifyResponse response);
 
+    void unnotify(String mac, UUID service, UUID character, BleNotifyResponse response);
+
     void unnotify(String mac, UUID service, UUID character, BleUnnotifyResponse response);
 
     void indicate(String mac, UUID service, UUID character, BleNotifyResponse response);


### PR DESCRIPTION
有时候在对设备的某个特征注册了多个通知监听，在某些情形下只需要移除其中某一个监听，但目前只提供了一次性解除某特征通知的所有监听的方法