### PR TITLE
新增requestConnectionPriority接口

### DIFF
--- a/library/src/main/java/com/inuker/bluetooth/library/BluetoothClient.java
+++ b/library/src/main/java/com/inuker/bluetooth/library/BluetoothClient.java
@@ -141,6 +141,12 @@ public class BluetoothClient implements IBluetoothClient {
     }
 
     @Override
+    public void requestConnectionPriority(String mac, int connectionPriority) {
+        BluetoothLog.v(String.format("requestConnectionPriority %s", mac));
+        mClient.requestConnectionPriority(mac, connectionPriority);
+    }
+
+    @Override
     public void search(SearchRequest request, SearchResponse response) {
         BluetoothLog.v(String.format("search %s", request));
 

--- a/library/src/main/java/com/inuker/bluetooth/library/BluetoothClientImpl.java
+++ b/library/src/main/java/com/inuker/bluetooth/library/BluetoothClientImpl.java
@@ -56,6 +56,7 @@ import static com.inuker.bluetooth.library.Constants.CODE_READ;
 import static com.inuker.bluetooth.library.Constants.CODE_READ_DESCRIPTOR;
 import static com.inuker.bluetooth.library.Constants.CODE_READ_RSSI;
 import static com.inuker.bluetooth.library.Constants.CODE_REFRESH_CACHE;
+import static com.inuker.bluetooth.library.Constants.CODE_REQUEST_PRIORITY;
 import static com.inuker.bluetooth.library.Constants.CODE_SEARCH;
 import static com.inuker.bluetooth.library.Constants.CODE_STOP_SESARCH;
 import static com.inuker.bluetooth.library.Constants.CODE_UNNOTIFY;
@@ -70,6 +71,7 @@ import static com.inuker.bluetooth.library.Constants.EXTRA_GATT_PROFILE;
 import static com.inuker.bluetooth.library.Constants.EXTRA_MAC;
 import static com.inuker.bluetooth.library.Constants.EXTRA_MTU;
 import static com.inuker.bluetooth.library.Constants.EXTRA_OPTIONS;
+import static com.inuker.bluetooth.library.Constants.EXTRA_PRIORITY;
 import static com.inuker.bluetooth.library.Constants.EXTRA_REQUEST;
 import static com.inuker.bluetooth.library.Constants.EXTRA_RSSI;
 import static com.inuker.bluetooth.library.Constants.EXTRA_SEARCH_RESULT;
@@ -418,7 +420,7 @@ public class BluetoothClientImpl implements IBluetoothClient, ProxyInterceptor, 
 
     @Override
     public void unindicate(String mac, UUID service, UUID character, BleUnnotifyResponse response) {
-       unnotify(mac, service, character, response);
+        unnotify(mac, service, character, response);
     }
 
     @Override
@@ -450,6 +452,14 @@ public class BluetoothClientImpl implements IBluetoothClient, ProxyInterceptor, 
                 }
             }
         });
+    }
+
+    @Override
+    public void requestConnectionPriority(String mac, int connectionPriority) {
+        Bundle args = new Bundle();
+        args.putString(EXTRA_MAC, mac);
+        args.putInt(EXTRA_PRIORITY, connectionPriority);
+        safeCallBluetoothApi(CODE_REQUEST_PRIORITY, args, null);
     }
 
     @Override

--- a/library/src/main/java/com/inuker/bluetooth/library/BluetoothServiceImpl.java
+++ b/library/src/main/java/com/inuker/bluetooth/library/BluetoothServiceImpl.java
@@ -25,6 +25,7 @@ import static com.inuker.bluetooth.library.Constants.CODE_READ_DESCRIPTOR;
 import static com.inuker.bluetooth.library.Constants.CODE_READ_RSSI;
 import static com.inuker.bluetooth.library.Constants.CODE_REFRESH_CACHE;
 import static com.inuker.bluetooth.library.Constants.CODE_REQUEST_MTU;
+import static com.inuker.bluetooth.library.Constants.CODE_REQUEST_PRIORITY;
 import static com.inuker.bluetooth.library.Constants.CODE_SEARCH;
 import static com.inuker.bluetooth.library.Constants.CODE_STOP_SESARCH;
 import static com.inuker.bluetooth.library.Constants.CODE_UNNOTIFY;
@@ -37,6 +38,7 @@ import static com.inuker.bluetooth.library.Constants.EXTRA_DESCRIPTOR_UUID;
 import static com.inuker.bluetooth.library.Constants.EXTRA_MAC;
 import static com.inuker.bluetooth.library.Constants.EXTRA_MTU;
 import static com.inuker.bluetooth.library.Constants.EXTRA_OPTIONS;
+import static com.inuker.bluetooth.library.Constants.EXTRA_PRIORITY;
 import static com.inuker.bluetooth.library.Constants.EXTRA_REQUEST;
 import static com.inuker.bluetooth.library.Constants.EXTRA_SERVICE_UUID;
 import static com.inuker.bluetooth.library.Constants.EXTRA_TYPE;
@@ -166,6 +168,10 @@ public class BluetoothServiceImpl extends IBluetoothService.Stub implements Hand
 
             case CODE_REFRESH_CACHE:
                 BleConnectManager.refreshCache(mac);
+                break;
+            case CODE_REQUEST_PRIORITY:
+                int priority = args.getInt(EXTRA_PRIORITY);
+                BleConnectManager.requestConnectionPriority(mac, priority);
                 break;
         }
         return true;

--- a/library/src/main/java/com/inuker/bluetooth/library/Constants.java
+++ b/library/src/main/java/com/inuker/bluetooth/library/Constants.java
@@ -28,6 +28,7 @@ public class Constants {
     public static final String EXTRA_OPTIONS = "extra.options";
     public static final String EXTRA_TYPE = "extra.type";
     public static final String EXTRA_MTU = "extra.mtu";
+    public static final String EXTRA_PRIORITY = "extra.priority";
 
     /**
      * CallBluetoothApi response code
@@ -79,6 +80,7 @@ public class Constants {
     public static final int CODE_CLEAR_REQUEST = 20;
     public static final int CODE_REFRESH_CACHE = 21;
     public static final int CODE_REQUEST_MTU = 22;
+    public static final int CODE_REQUEST_PRIORITY = 23;
 
     public static final int STATUS_UNKNOWN = -1;
     public static final int STATUS_DEVICE_CONNECTED = BluetoothProfile.STATE_CONNECTED;
@@ -94,12 +96,18 @@ public class Constants {
 
     public static String getStatusText(int status) {
         switch (status) {
-            case Constants.STATUS_DEVICE_CONNECTED: return "Connected";
-            case Constants.STATUS_DEVICE_CONNECTING: return "Connecting";
-            case Constants.STATUS_DEVICE_DISCONNECTING: return "Disconnecting";
-            case Constants.STATUS_DEVICE_DISCONNECTED: return "Disconnected";
-            case Constants.STATUS_DEVICE_SERVICE_READY: return "Service Ready";
-            default: return String.format("Unknown %d", status);
+            case Constants.STATUS_DEVICE_CONNECTED:
+                return "Connected";
+            case Constants.STATUS_DEVICE_CONNECTING:
+                return "Connecting";
+            case Constants.STATUS_DEVICE_DISCONNECTING:
+                return "Disconnecting";
+            case Constants.STATUS_DEVICE_DISCONNECTED:
+                return "Disconnected";
+            case Constants.STATUS_DEVICE_SERVICE_READY:
+                return "Service Ready";
+            default:
+                return String.format("Unknown %d", status);
         }
     }
 
@@ -114,4 +122,9 @@ public class Constants {
 
     public static final int GATT_DEF_BLE_MTU_SIZE = 23;
     public static final int GATT_MAX_MTU_SIZE = 517;
+
+    public static final int PRIORITY_BALANCED = 0;
+    public static final int PRIORITY_HIGH = 1;
+    public static final int PRIORITY_LOW_POWER = 2;
+
 }

--- a/library/src/main/java/com/inuker/bluetooth/library/IBluetoothClient.java
+++ b/library/src/main/java/com/inuker/bluetooth/library/IBluetoothClient.java
@@ -51,6 +51,8 @@ public interface IBluetoothClient {
 
     void requestMtu(String mac, int mtu, BleMtuResponse response);
 
+    void requestConnectionPriority(String mac, int connectionPriority);
+
     void search(SearchRequest request, SearchResponse response);
 
     void stopSearch();

--- a/library/src/main/java/com/inuker/bluetooth/library/connect/BleConnectDispatcher.java
+++ b/library/src/main/java/com/inuker/bluetooth/library/connect/BleConnectDispatcher.java
@@ -12,6 +12,7 @@ import com.inuker.bluetooth.library.connect.request.BleConnectRequest;
 import com.inuker.bluetooth.library.connect.request.BleIndicateRequest;
 import com.inuker.bluetooth.library.connect.request.BleMtuRequest;
 import com.inuker.bluetooth.library.connect.request.BleNotifyRequest;
+import com.inuker.bluetooth.library.connect.request.BlePriorityRequest;
 import com.inuker.bluetooth.library.connect.request.BleReadDescriptorRequest;
 import com.inuker.bluetooth.library.connect.request.BleReadRequest;
 import com.inuker.bluetooth.library.connect.request.BleReadRssiRequest;
@@ -162,6 +163,10 @@ public class BleConnectDispatcher implements IBleConnectDispatcher, RuntimeCheck
 
     public void requestMtu(int mtu, BleGeneralResponse response) {
         addNewRequest(new BleMtuRequest(mtu, response));
+    }
+
+    public void requestConnectionPriority(int priority) {
+        addNewRequest(new BlePriorityRequest(priority, null));
     }
 
     private void addNewRequest(BleRequest request) {

--- a/library/src/main/java/com/inuker/bluetooth/library/connect/BleConnectManager.java
+++ b/library/src/main/java/com/inuker/bluetooth/library/connect/BleConnectManager.java
@@ -92,6 +92,10 @@ public class BleConnectManager {
         getBleConnectMaster(mac).requestMtu(mtu, response);
     }
 
+    public static void requestConnectionPriority(String mac, int priority) {
+        getBleConnectMaster(mac).requestConnectionPriority(priority);
+    }
+
     public static void clearRequest(String mac, int type) {
         getBleConnectMaster(mac).clearRequest(type);
     }

--- a/library/src/main/java/com/inuker/bluetooth/library/connect/BleConnectMaster.java
+++ b/library/src/main/java/com/inuker/bluetooth/library/connect/BleConnectMaster.java
@@ -103,6 +103,11 @@ public class BleConnectMaster implements IBleConnectMaster, ProxyInterceptor, Ca
     }
 
     @Override
+    public void requestConnectionPriority(int connectionPriority) {
+        getConnectDispatcher().requestConnectionPriority(connectionPriority);
+    }
+
+    @Override
     public void clearRequest(int clearType) {
         getConnectDispatcher().clearRequest(clearType);
     }

--- a/library/src/main/java/com/inuker/bluetooth/library/connect/BleConnectWorker.java
+++ b/library/src/main/java/com/inuker/bluetooth/library/connect/BleConnectWorker.java
@@ -288,7 +288,7 @@ public class BleConnectWorker implements Handler.Callback, IBleConnectWorker, IB
     }
 
     private void broadcastCharacterChanged(UUID service, UUID character,
-    byte[] value) {
+                                           byte[] value) {
         Intent intent = new Intent(
                 Constants.ACTION_CHARACTER_CHANGED);
         intent.putExtra(Constants.EXTRA_MAC,
@@ -713,6 +713,30 @@ public class BleConnectWorker implements Handler.Callback, IBleConnectWorker, IB
 
         if (!mBluetoothGatt.requestMtu(mtu)) {
             BluetoothLog.e(String.format("requestMtu failed"));
+            return false;
+        }
+        return true;
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @Override
+    public boolean requestConnectionPriority(int connectionPriority) {
+        checkRuntime();
+
+        BluetoothLog.v(String.format("requestConnectionPriority for %s, priority = %s", getAddress(), connectionPriority));
+
+        if (connectionPriority < Constants.PRIORITY_BALANCED ||
+                connectionPriority > Constants.PRIORITY_LOW_POWER) {
+            BluetoothLog.e(String.format("requestConnectionPriority- params: %s not within valid range", connectionPriority));
+            return false;
+        }
+        if (mBluetoothGatt == null) {
+            BluetoothLog.e("ble gatt null");
+            return false;
+        }
+
+        if (!mBluetoothGatt.requestConnectionPriority(connectionPriority)) {
+            BluetoothLog.e("requestConnectionPriority failed");
             return false;
         }
         return true;

--- a/library/src/main/java/com/inuker/bluetooth/library/connect/IBleConnectMaster.java
+++ b/library/src/main/java/com/inuker/bluetooth/library/connect/IBleConnectMaster.java
@@ -34,6 +34,8 @@ public interface IBleConnectMaster {
 
     void requestMtu(int mtu, BleGeneralResponse response);
 
+    void requestConnectionPriority(int connectionPriority);
+
     void clearRequest(int clearType);
 
     void refreshCache();

--- a/library/src/main/java/com/inuker/bluetooth/library/connect/IBleConnectWorker.java
+++ b/library/src/main/java/com/inuker/bluetooth/library/connect/IBleConnectWorker.java
@@ -43,5 +43,7 @@ public interface IBleConnectWorker {
 
     boolean requestMtu(int mtu);
 
+    boolean requestConnectionPriority(int connectionPriority);
+
     BleGattProfile getGattProfile();
 }

--- a/library/src/main/java/com/inuker/bluetooth/library/connect/request/BlePriorityRequest.java
+++ b/library/src/main/java/com/inuker/bluetooth/library/connect/request/BlePriorityRequest.java
@@ -1,0 +1,39 @@
+package com.inuker.bluetooth.library.connect.request;
+
+import com.inuker.bluetooth.library.Code;
+import com.inuker.bluetooth.library.Constants;
+import com.inuker.bluetooth.library.connect.response.BleGeneralResponse;
+
+public class BlePriorityRequest extends BleRequest {
+
+    private int priority;
+
+    public BlePriorityRequest(int priority, BleGeneralResponse response) {
+        super(response);
+        this.priority = priority;
+    }
+
+    @Override
+    public void processRequest() {
+        switch (getCurrentStatus()) {
+
+            case Constants.STATUS_DEVICE_CONNECTED:
+            case Constants.STATUS_DEVICE_SERVICE_READY:
+                requestConnectionPriority();
+                break;
+
+            default://Constants.STATUS_DEVICE_DISCONNECTED or Others
+                onRequestCompleted(Code.REQUEST_FAILED);
+                break;
+        }
+    }
+
+    private void requestConnectionPriority() {
+        if (!requestConnectionPriority(priority)) {
+            onRequestCompleted(Code.REQUEST_FAILED);
+        } else {
+            onRequestCompleted(Code.REQUEST_SUCCESS);
+        }
+    }
+
+}

--- a/library/src/main/java/com/inuker/bluetooth/library/connect/request/BleRequest.java
+++ b/library/src/main/java/com/inuker/bluetooth/library/connect/request/BleRequest.java
@@ -249,6 +249,11 @@ public abstract class BleRequest implements IBleConnectWorker, IBleRequest, Hand
         return mWorker.requestMtu(mtu);
     }
 
+    @Override
+    public boolean requestConnectionPriority(int connectionPriority) {
+        return mWorker.requestConnectionPriority(connectionPriority);
+    }
+
     protected void log(String msg) {
         BluetoothLog.v(String.format("%s %s >>> %s", getClass().getSimpleName(), getAddress(), msg));
     }


### PR DESCRIPTION
requestConnectionPriority(int priority)
参数：
```
Constants.PRIORITY_BALANCED = 0;//默认的值
Constants.PRIORITY_HIGH = 1;//连接快的值，当需要跟设备进行大的数据传输时设置该值
Constants.PRIORITY_LOW_POWER = 2;//低功耗的值
```
该接口是5.0以上的API，连接成功后，大数据传输前，调用此接口`Constants.PRIORITY_HIGH` 可以有更快的传输速度。

**真机实测**：
(自己加了延迟10ms发送一包。在小米手机上实测，设置`Constants.PRIORITY_HIGH`该值后，不加延迟一顿猛发容易丢包，所以最好加上10毫秒的延迟)

魅族16sPro测试，调用或者不调用，速度都很快，20k图片BLE设备端接收完成都是20秒左右。
小米8SE测试，发送20k的图片，BLE设备端完全接收**从1分多钟降到了20秒**左右。

所以此接口还是有效的，具体效果看手机厂商底层的连接间隔。